### PR TITLE
Migrate to Android Studio Bumblebee

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -20,7 +20,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    lintOptions {
+    lint {
         abortOnError false
     }
 }

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -15,12 +15,6 @@
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'
 
-android {
-    androidResources {
-        noCompress 'tflite'
-    }
-}
-
 
 dependencies {
     implementation project(':FtcRobotController')
@@ -38,12 +32,25 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
 android {
+
+
+    androidResources {
+        noCompress 'tflite'
+    }
+    packagingOptions {
+        jniLibs {
+            pickFirsts += ['**/*.so', '**/*.so']
+        }
+    }
+    lint {
+        abortOnError false
+    }
     defaultConfig {
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.1.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 02 19:11:46 EST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 24 14:30:03 PDT 2020
+#Wed Feb 02 19:11:46 EST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR covers everything that should come with the migration to Android Studio Bumblebee (from Arctic Fox).

- [ ] Apply any fixes necessary for migration
- [x] Bump Gradle and Gradle plugin versions

A side note, Bumblebee introduces a [new device manager](https://developer.android.com/studio/releases#new-device-manager) and [wireless debugging](https://developer.android.com/studio/releases#wireless-debugging). Hopefully there is a way to use these tools to their fullest capabilities. 

## Some more notes

- Bumblebee also upgrades the base IntelliJ IDE platform to 2021.1.1.
  - Because of this, the Lombok plugin is merged into the IDE's main codebase. If you have the Lombok plugin, you can uninstall it.
- I may update this PR with more notices as I find them.
- This PR is going to remain a draft for a few days while I test out Bumblebee. After that, it should be safe to merge.
