### PR TITLE
Cleanup the code

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/GyroTracker.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/GyroTracker.java
@@ -28,7 +28,7 @@ public class GyroTracker {
     }
 
     public static void loop() {
-        currentAcceleration = Robot.gyro1.getLinearAcceleration();
+        currentAcceleration = Robot.getGyro1().getLinearAcceleration();
         totalAcceleration.xAccel += currentAcceleration.xAccel;
         totalAcceleration.yAccel += currentAcceleration.yAccel;
         totalAcceleration.zAccel += currentAcceleration.zAccel;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -27,9 +27,9 @@ import com.qualcomm.robotcore.hardware.Servo;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.api.bp.AbstractRobot;
-import org.firstinspires.ftc.teamcode.api.bp.ArmRobot;
 import org.firstinspires.ftc.teamcode.api.bp.DistanceSensorRobot;
 import org.firstinspires.ftc.teamcode.api.bp.DuckRobot;
+import org.firstinspires.ftc.teamcode.api.bp.TwoArmRobot;
 import org.firstinspires.ftc.teamcode.api.bp.WheeledRobot;
 import org.firstinspires.ftc.teamcode.api.config.Constants;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutorService;
 import lombok.Getter;
 import lombok.Setter;
 
-public class Robot extends AbstractRobot implements WheeledRobot, DuckRobot, ArmRobot, DistanceSensorRobot {
+public class Robot extends AbstractRobot implements WheeledRobot, DuckRobot, TwoArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     @Getter

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -79,12 +79,12 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.clawRight.setPosition(position);
     }
 
-    public void positionArmO(double position) {
+    public void positionArm2(double position) {
         this.armLeft2.setPosition(position);
         this.armRight2.setPosition(position);
     }
 
-    public void positionClawO(double position) {
+    public void positionClaw2(double position) {
         this.clawLeft2.setPosition(position);
         this.clawRight2.setPosition(position);
     }
@@ -95,7 +95,7 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.clawRight.setPosition(this.clawRight.getPosition() + amount);
     }
 
-    public void adjustClawO(double amount) {
+    public void adjustClaw2(double amount) {
         this.clawLeft2.setPosition(this.clawLeft2.getPosition() + amount);
         this.clawRight2.setPosition(this.clawRight2.getPosition() + amount);
     }
@@ -110,12 +110,12 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.positionClaw(0.2);
     }
 
-    public void openClawO() {
-        this.positionClawO(0.1);
+    public void openClaw2() {
+        this.positionClaw2(0.1);
     }
 
-    public void closeClawO() {
-        this.positionClawO(0.2);
+    public void closeClaw2() {
+        this.positionClaw2(0.2);
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -29,6 +29,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.api.bp.AbstractRobot;
 import org.firstinspires.ftc.teamcode.api.bp.ArmRobot;
 import org.firstinspires.ftc.teamcode.api.bp.DistanceSensorRobot;
+import org.firstinspires.ftc.teamcode.api.bp.DuckRobot;
 import org.firstinspires.ftc.teamcode.api.bp.WheeledRobot;
 import org.firstinspires.ftc.teamcode.api.config.Constants;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
@@ -42,7 +43,7 @@ import java.util.concurrent.ExecutorService;
 import lombok.Getter;
 import lombok.Setter;
 
-public class Robot extends AbstractRobot implements WheeledRobot, ArmRobot, DistanceSensorRobot {
+public class Robot extends AbstractRobot implements WheeledRobot, DuckRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     @Getter

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -29,7 +29,6 @@ import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.api.bp.AbstractRobot;
 import org.firstinspires.ftc.teamcode.api.bp.ArmRobot;
 import org.firstinspires.ftc.teamcode.api.bp.DistanceSensorRobot;
-import org.firstinspires.ftc.teamcode.api.bp.StepWheeledRobot;
 import org.firstinspires.ftc.teamcode.api.bp.WheeledRobot;
 import org.firstinspires.ftc.teamcode.api.config.Constants;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
@@ -46,7 +45,6 @@ import lombok.Setter;
 public class Robot extends AbstractRobot implements WheeledRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
-    // Discuss if private is better idea
     @Getter
     private SmartMotor bl, br, fl, fr, duck;
     @Getter

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -18,14 +18,10 @@ package org.firstinspires.ftc.teamcode.api;
 
 import androidx.annotation.NonNull;
 
-import com.qualcomm.hardware.bosch.BNO055IMU;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.hardware.ColorSensor;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.DistanceSensor;
-import com.qualcomm.robotcore.hardware.NormalizedColorSensor;
 import com.qualcomm.robotcore.hardware.Servo;
 
 import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
@@ -42,17 +38,14 @@ import org.firstinspires.ftc.teamcode.api.hw.SmartColorSensor;
 import org.firstinspires.ftc.teamcode.api.hw.SmartMotor;
 import org.firstinspires.ftc.teamcode.api.hw.SmartServo;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import lombok.Getter;
 
 public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     // Discuss if private is better idea
-    public SmartMotor bl, br, fl, fr, duck, left, right;
+    public SmartMotor bl, br, fl, fr, duck;
     public SmartServo armLeft, armRight, clawLeft, clawRight, clawLefto, clawRighto, armLefto, armRighto;
     public DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
     public SmartColorSensor parkSensor;
@@ -64,7 +57,6 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         super(opMode);
     }
 
-    // Wheels
     @Override
     public void powerWheels(double flPower, double frPower, double blPower, double brPower) {
         this.fl.setPower(flPower);
@@ -72,8 +64,6 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.bl.setPower(blPower);
         this.br.setPower(brPower);
     }
-
-    // Arm
 
     @Override
     public void positionArm(double position) {
@@ -100,17 +90,8 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
 
     @Override
     public void adjustClaw(double amount) {
-        // Version 1
         this.clawLeft.setPosition(this.clawLeft.getPosition() + amount);
         this.clawRight.setPosition(this.clawRight.getPosition() + amount);
-
-        // Version 2
-
-        /*
-        * double finalPosition = this.clawLeft.getPosition() + amount;
-        * this.clawLeft.setPosition(finalPosition);
-        * this.clawRight.setPosition(finalPosition);
-        */
     }
 
     public void adjustClawO(double amount) {
@@ -142,7 +123,8 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
     }
 
     @Deprecated
-    public void powerStepWheels(double leftPower, double rightPower) {}
+    public void powerStepWheels(double leftPower, double rightPower) {
+    }
 
     @Override
     public double getFLDistance() {
@@ -166,13 +148,7 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
 
     @Override
     public void initTeleOp(@NonNull OpMode opMode) {
-        // Threading or something
-        ExecutorService executorService = Executors.newFixedThreadPool(Constants.THREADS);
-
-        // For future reference
         this.opMode = opMode;
-
-        // InitRobot has an executor service, not sure if that should be included here
 
         // Motors
         this.bl = new SmartMotor(opMode.hardwareMap.get(DcMotorEx.class, Naming.MOTOR_BL));

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -46,13 +46,20 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
     public static ExecutorService executorService;
 
     // Discuss if private is better idea
-    @Getter private SmartMotor bl, br, fl, fr, duck;
-    @Getter private SmartServo armLeft, armRight, clawLeft, clawRight, clawLeft2, clawRight2, armLeft2, armRight2;
-    @Getter private DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
-    @Getter private SmartColorSensor parkSensor;
-    @Getter private WebcamName webcam0;
-    @Getter private static Gyroscope gyro0, gyro1;
-    @Getter private OpMode opMode;
+    @Getter
+    private SmartMotor bl, br, fl, fr, duck;
+    @Getter
+    private SmartServo armLeft, armRight, clawLeft, clawRight, clawLeft2, clawRight2, armLeft2, armRight2;
+    @Getter
+    private DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
+    @Getter
+    private SmartColorSensor parkSensor;
+    @Getter
+    private WebcamName webcam0;
+    @Getter
+    private static Gyroscope gyro0, gyro1;
+    @Getter
+    private OpMode opMode;
 
     public Robot(OpMode opMode) {
         super(opMode);
@@ -66,18 +73,32 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.br.setPower(brPower);
     }
 
+    // Arm 1
+
     @Override
     public void positionArm(double position) {
         this.armLeft.setPosition(position);
         this.armRight.setPosition(position);
     }
 
-
     @Override
     public void positionClaw(double position) {
         this.clawLeft.setPosition(position);
         this.clawRight.setPosition(position);
     }
+
+    public void adjustArm(double amount) {
+        this.armLeft.setPosition(this.armLeft.getPosition() + amount);
+        this.armRight.setPosition(this.armRight.getPosition() + amount);
+    }
+
+    @Override
+    public void adjustClaw(double amount) {
+        this.clawLeft.setPosition(this.clawLeft.getPosition() + amount);
+        this.clawRight.setPosition(this.clawRight.getPosition() + amount);
+    }
+
+    // Arm 2
 
     public void positionArm2(double position) {
         this.armLeft2.setPosition(position);
@@ -89,10 +110,9 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.clawRight2.setPosition(position);
     }
 
-    @Override
-    public void adjustClaw(double amount) {
-        this.clawLeft.setPosition(this.clawLeft.getPosition() + amount);
-        this.clawRight.setPosition(this.clawRight.getPosition() + amount);
+    public void adjustArm2(double amount) {
+        this.armLeft2.setPosition(this.armLeft2.getPosition() + amount);
+        this.armRight2.setPosition(this.armRight2.getPosition() + amount);
     }
 
     public void adjustClaw2(double amount) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -122,10 +122,6 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.duck.setPower(power);
     }
 
-    @Deprecated
-    public void powerStepWheels(double leftPower, double rightPower) {
-    }
-
     @Override
     public double getFLDistance() {
         return this.distanceFL.getDistance(DistanceUnit.CM);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -40,17 +40,19 @@ import org.firstinspires.ftc.teamcode.api.hw.SmartServo;
 
 import java.util.concurrent.ExecutorService;
 
+import lombok.Getter;
+
 public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     // Discuss if private is better idea
-    public SmartMotor bl, br, fl, fr, duck;
-    public SmartServo armLeft, armRight, clawLeft, clawRight, clawLeft2, clawRight2, armLeft2, armRight2;
-    public DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
-    public SmartColorSensor parkSensor;
-    public WebcamName webcam0;
-    public static Gyroscope gyro0, gyro1;
-    private OpMode opMode;
+    @Getter private SmartMotor bl, br, fl, fr, duck;
+    @Getter private SmartServo armLeft, armRight, clawLeft, clawRight, clawLeft2, clawRight2, armLeft2, armRight2;
+    @Getter private DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
+    @Getter private SmartColorSensor parkSensor;
+    @Getter private WebcamName webcam0;
+    @Getter private static Gyroscope gyro0, gyro1;
+    @Getter private OpMode opMode;
 
     public Robot(OpMode opMode) {
         super(opMode);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -101,21 +101,25 @@ public class Robot extends AbstractRobot implements WheeledRobot, DuckRobot, Two
 
     // Arm 2
 
+    @Override
     public void positionArm2(double position) {
         this.armLeft2.setPosition(position);
         this.armRight2.setPosition(position);
     }
 
+    @Override
     public void positionClaw2(double position) {
         this.clawLeft2.setPosition(position);
         this.clawRight2.setPosition(position);
     }
 
+    @Override
     public void adjustArm2(double amount) {
         this.armLeft2.setPosition(this.armLeft2.getPosition() + amount);
         this.armRight2.setPosition(this.armRight2.getPosition() + amount);
     }
 
+    @Override
     public void adjustClaw2(double amount) {
         this.clawLeft2.setPosition(this.clawLeft2.getPosition() + amount);
         this.clawRight2.setPosition(this.clawRight2.getPosition() + amount);
@@ -131,10 +135,12 @@ public class Robot extends AbstractRobot implements WheeledRobot, DuckRobot, Two
         this.positionClaw(0.2);
     }
 
+    @Override
     public void openClaw2() {
         this.positionClaw2(0.1);
     }
 
+    @Override
     public void closeClaw2() {
         this.positionClaw2(0.2);
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -39,14 +39,13 @@ import org.firstinspires.ftc.teamcode.api.hw.SmartMotor;
 import org.firstinspires.ftc.teamcode.api.hw.SmartServo;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     // Discuss if private is better idea
     public SmartMotor bl, br, fl, fr, duck;
-    public SmartServo armLeft, armRight, clawLeft, clawRight, clawLefto, clawRighto, armLefto, armRighto;
+    public SmartServo armLeft, armRight, clawLeft, clawRight, clawLeft2, clawRight2, armLeft2, armRight2;
     public DistanceSensor distanceFL, distanceFR, distanceBL, distanceBR;
     public SmartColorSensor parkSensor;
     public WebcamName webcam0;
@@ -79,13 +78,13 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
     }
 
     public void positionArmO(double position) {
-        this.armLefto.setPosition(position);
-        this.armRighto.setPosition(position);
+        this.armLeft2.setPosition(position);
+        this.armRight2.setPosition(position);
     }
 
     public void positionClawO(double position) {
-        this.clawLefto.setPosition(position);
-        this.clawRighto.setPosition(position);
+        this.clawLeft2.setPosition(position);
+        this.clawRight2.setPosition(position);
     }
 
     @Override
@@ -95,8 +94,8 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
     }
 
     public void adjustClawO(double amount) {
-        this.clawLefto.setPosition(this.clawLefto.getPosition() + amount);
-        this.clawRighto.setPosition(this.clawRighto.getPosition() + amount);
+        this.clawLeft2.setPosition(this.clawLeft2.getPosition() + amount);
+        this.clawRight2.setPosition(this.clawRight2.getPosition() + amount);
     }
 
     @Override
@@ -160,10 +159,10 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.clawLeft = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_LEFT));
         this.clawRight = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_RIGHT));
 
-        this.armLefto = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_ARM_LEFTo));
-        this.armRighto = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_ARM_RIGHTo));
-        this.clawLefto = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_LEFTo));
-        this.clawRighto = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_RIGHTo));
+        this.armLeft2 = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_ARM_LEFTo));
+        this.armRight2 = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_ARM_RIGHTo));
+        this.clawLeft2 = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_LEFTo));
+        this.clawRight2 = new SmartServo(opMode.hardwareMap.get(Servo.class, Naming.SERVO_CLAW_RIGHTo));
 
         // Sensors
         this.distanceFL = opMode.hardwareMap.get(DistanceSensor.class, Naming.SENSOR_DISTANCE_FL);
@@ -195,10 +194,10 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
         this.clawLeft.setDirection(Servo.Direction.FORWARD);
         this.clawRight.setDirection(Servo.Direction.REVERSE);
 
-        this.armLefto.setDirection(Servo.Direction.FORWARD);
-        this.armRighto.setDirection(Servo.Direction.REVERSE);
-        this.clawLefto.setDirection(Servo.Direction.FORWARD);
-        this.clawRighto.setDirection(Servo.Direction.REVERSE);
+        this.armLeft2.setDirection(Servo.Direction.FORWARD);
+        this.armRight2.setDirection(Servo.Direction.REVERSE);
+        this.clawLeft2.setDirection(Servo.Direction.FORWARD);
+        this.clawRight2.setDirection(Servo.Direction.REVERSE);
 
         this.bl.setPowerModifier(Constants.MOTOR_BL_POWER_MOD);
         this.br.setPowerModifier(Constants.MOTOR_BR_POWER_MOD);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/Robot.java
@@ -41,8 +41,9 @@ import org.firstinspires.ftc.teamcode.api.hw.SmartServo;
 import java.util.concurrent.ExecutorService;
 
 import lombok.Getter;
+import lombok.Setter;
 
-public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRobot, ArmRobot, DistanceSensorRobot {
+public class Robot extends AbstractRobot implements WheeledRobot, ArmRobot, DistanceSensorRobot {
     public static ExecutorService executorService;
 
     // Discuss if private is better idea
@@ -57,6 +58,7 @@ public class Robot extends AbstractRobot implements WheeledRobot, StepWheeledRob
     @Getter
     private WebcamName webcam0;
     @Getter
+    @Setter
     private static Gyroscope gyro0, gyro1;
     @Getter
     private OpMode opMode;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/ArmRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/ArmRobot.java
@@ -1,22 +1,21 @@
 package org.firstinspires.ftc.teamcode.api.bp;
 
 public interface ArmRobot {
-    default void powerDuck(double power) {}
-
-    default void positionArm(double position) {}
-
-    // Adjusts position of arm relative to its current position.
-    default void adjustArm(double amount) {
-        // this.positionArmBase(servo.getPosition() + amount);
+    default void positionArm(double position) {
     }
 
-    default void positionClaw(double position) {}
-    default void adjustClaw(double amount) {}
+    default void adjustArm(double amount) {
+    }
+
+    default void positionClaw(double position) {
+    }
+
+    default void adjustClaw(double amount) {
+    }
 
     default void openClaw() {
-        // this.positionClaw(0.9)
     }
+
     default void closeClaw() {
-        // this.positionClaw(0.2)
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/DistanceSensorRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/DistanceSensorRobot.java
@@ -1,20 +1,20 @@
 package org.firstinspires.ftc.teamcode.api.bp;
 
 public interface DistanceSensorRobot {
-    default public double getFrontDistance() {
+    default double getFrontDistance() {
         return (
             this.getFLDistance() + this.getFRDistance()
         ) / 2;
     }
 
-    default public double getBackDistance() {
+    default double getBackDistance() {
         return (
             this.getBLDistance() + this.getBRDistance()
         ) / 2;
     }
 
-    public double getFLDistance();
-    public double getFRDistance();
-    public double getBLDistance();
-    public double getBRDistance();
+    double getFLDistance();
+    double getFRDistance();
+    double getBLDistance();
+    double getBRDistance();
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/DuckRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/DuckRobot.java
@@ -1,0 +1,6 @@
+package org.firstinspires.ftc.teamcode.api.bp;
+
+public interface DuckRobot {
+    default void powerDuck(double power) {
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/StepWheeledRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/StepWheeledRobot.java
@@ -1,7 +1,0 @@
-package org.firstinspires.ftc.teamcode.api.bp;
-
-@Deprecated
-public interface StepWheeledRobot {
-    default void powerStepWheels(double leftPower, double rightPower) {}
-    default void powerStepWheels(double power) {this.powerStepWheels(power, power);};
-}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/TwoArmRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/bp/TwoArmRobot.java
@@ -1,0 +1,21 @@
+package org.firstinspires.ftc.teamcode.api.bp;
+
+public interface TwoArmRobot extends ArmRobot {
+    default void positionArm2(double position) {
+    }
+
+    default void adjustArm2(double amount) {
+    }
+
+    default void positionClaw2(double position) {
+    }
+
+    default void adjustClaw2(double amount) {
+    }
+
+    default void openClaw2() {
+    }
+
+    default void closeClaw2() {
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/hw/Gyroscope.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/hw/Gyroscope.java
@@ -5,9 +5,6 @@ import com.qualcomm.hardware.bosch.JustLoggingAccelerationIntegrator;
 import com.qualcomm.robotcore.util.ReadWriteFile;
 
 import org.firstinspires.ftc.robotcore.external.navigation.Acceleration;
-import org.firstinspires.ftc.robotcore.external.navigation.Position;
-import org.firstinspires.ftc.robotcore.external.navigation.Quaternion;
-import org.firstinspires.ftc.robotcore.external.navigation.Velocity;
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 
 import java.io.File;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/opsystems/Controller.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/api/opsystems/Controller.java
@@ -4,7 +4,6 @@ import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.hardware.Gamepad;
-import com.qualcomm.robotcore.util.Range;
 
 import org.firstinspires.ftc.teamcode.api.Robot;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/MoveForward2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/MoveForward2.java
@@ -39,11 +39,9 @@ public class MoveForward2 extends LinearOpMode {
 
         while (runtime.seconds() < 2 && opModeIsActive()) {
             robot.powerWheels(1);
-            robot.powerStepWheels(1);
         }
 
         robot.powerWheels(0);
-        robot.powerStepWheels(0);
 
         telemetry.addData("Status", "Finished");
         telemetry.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/SensorSmartDuck.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/SensorSmartDuck.java
@@ -26,10 +26,10 @@ public class SensorSmartDuck extends LinearOpMode {
 
         robot.closeClaw();
 
-        robot.armLeft.setPwmEnable();
-        robot.armRight.setPwmEnable();
-        robot.clawLeft.setPwmEnable();
-        robot.clawRight.setPwmEnable();
+        robot.getArmLeft().setPwmEnable();
+        robot.getArmRight().setPwmEnable();
+        robot.getClawLeft().setPwmEnable();
+        robot.getClawRight().setPwmEnable();
 
         // Move backwards into duck wheel
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/SensorSmartDuck.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/SensorSmartDuck.java
@@ -2,10 +2,8 @@ package org.firstinspires.ftc.teamcode.opmode.autonomous;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
-import com.qualcomm.robotcore.hardware.DistanceSensor;
 import com.qualcomm.robotcore.util.ElapsedTime;
 
-import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.api.Robot;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
 
@@ -32,7 +30,6 @@ public class SensorSmartDuck extends LinearOpMode {
         robot.getClawRight().setPwmEnable();
 
         // Move backwards into duck wheel
-
         runtime = new ElapsedTime();
 
         while (robot.getBackDistance() > 20 && runtime.seconds() < 5 && opModeIsActive()) {
@@ -40,11 +37,9 @@ public class SensorSmartDuck extends LinearOpMode {
         }
 
         robot.powerWheels(0);
-
         sleep(500);
 
         // Spin duck wheel
-
         runtime = new ElapsedTime();
 
         while (runtime.seconds() < 3 && opModeIsActive()) {
@@ -52,29 +47,19 @@ public class SensorSmartDuck extends LinearOpMode {
         }
 
         robot.powerDuck(0);
-
         sleep(500);
 
         // Move left
-
-        runtime = new ElapsedTime();
-
-        while (runtime.seconds() < 0.85 && opModeIsActive()) {
-            robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
-        }
-
+        robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
+        sleep(850);
         robot.powerWheels(0);
-
         sleep(500);
 
         // Raise Arm
-
         robot.positionArm(0.718);
-
         sleep(500);
 
         // Move forward into warehouse
-
         runtime = new ElapsedTime();
 
         while (robot.getFRDistance() > 80 && runtime.seconds() < 5 && opModeIsActive()) {
@@ -83,8 +68,7 @@ public class SensorSmartDuck extends LinearOpMode {
 
         robot.powerWheels(0);
 
-        // Finalize
-
+        // Done!
         telemetry.addData("Status", "Finished");
         telemetry.update();
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
@@ -1,15 +1,17 @@
 package org.firstinspires.ftc.teamcode.opmode.autonomous;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.hardware.DistanceSensor;
-import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.api.Robot;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
 
 @Autonomous(name = "Timed Smart Duck", group = Naming.OPMODE_GROUP_COMP)
+@Disabled
+@Deprecated
 public class TimedSmartDuck extends LinearOpMode {
     @Override
     public void runOpMode() {
@@ -33,63 +35,37 @@ public class TimedSmartDuck extends LinearOpMode {
         robot.getClawRight().setPwmEnable();
 
         // Move left a little bit
-        ElapsedTime runtime = new ElapsedTime();
-
-        while (runtime.seconds() < 0.25 && opModeIsActive()) {
-            robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
-        }
-
+        robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
+        sleep(250);
         robot.powerWheels(0);
+        sleep(500);
 
         // Move to backwards
-        runtime = new ElapsedTime();
-
-        while (runtime.seconds() < 2.25 && opModeIsActive()) {
-            robot.powerWheels(-0.5);
-        }
-
+        robot.powerWheels(-0.5);
+        sleep(2250);
         robot.powerWheels(0);
-
         sleep(500);
 
         // Power duck wheel
-        runtime = new ElapsedTime();
-
-        while (runtime.seconds() < 3 && opModeIsActive()) {
-            robot.powerDuck(-0.7);
-        }
-
+        robot.powerDuck(-0.7);
+        sleep(3000);
         robot.powerDuck(0);
-
         sleep(500);
 
         // Move left
-        runtime = new ElapsedTime();
-
-        while (runtime.seconds() < 0.75 && opModeIsActive()) {
-            robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
-        }
-
+        robot.powerWheels(-0.5, 0.5, 0.5, -0.5);
+        sleep(750);
         robot.powerWheels(0);
-
         sleep(500);
 
         // Raise arm
         robot.positionArm(0.718);
-
         sleep(500);
 
-        // Move forward into warehouse
-        runtime = new ElapsedTime();
-
-        /* while (runtime.seconds() < 3 && opModeIsActive()) {
-            robot.powerWheels(1);
-            robot.powerStepWheels(1);
-        } */
-
+        // Move to warehouse
         while (
                 (sensorL.getDistance(DistanceUnit.CM) + sensorR.getDistance(DistanceUnit.CM)) / 2 > 90
-                && opModeIsActive()
+                        && opModeIsActive()
         ) {
             robot.powerWheels(1);
             robot.powerStepWheels(1);
@@ -97,6 +73,7 @@ public class TimedSmartDuck extends LinearOpMode {
 
         robot.powerWheels(0);
 
+        // Done!
         telemetry.addData("Status", "Finished");
         telemetry.update();
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
@@ -27,10 +27,10 @@ public class TimedSmartDuck extends LinearOpMode {
 
         robot.closeClaw();
 
-        robot.armLeft.setPwmEnable();
-        robot.armRight.setPwmEnable();
-        robot.clawLeft.setPwmEnable();
-        robot.clawRight.setPwmEnable();
+        robot.getArmLeft().setPwmEnable();
+        robot.getArmRight().setPwmEnable();
+        robot.getClawLeft().setPwmEnable();
+        robot.getClawRight().setPwmEnable();
 
         // Move left a little bit
         ElapsedTime runtime = new ElapsedTime();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/autonomous/TimedSmartDuck.java
@@ -68,7 +68,6 @@ public class TimedSmartDuck extends LinearOpMode {
                         && opModeIsActive()
         ) {
             robot.powerWheels(1);
-            robot.powerStepWheels(1);
         }
 
         robot.powerWheels(0);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/AsyncServoTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/AsyncServoTest.java
@@ -3,16 +3,13 @@ package org.firstinspires.ftc.teamcode.opmode.teleop;
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
-import com.qualcomm.hardware.bosch.BNO055IMU;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.ServoImplEx;
 
-import org.firstinspires.ftc.teamcode.api.GyroTracker;
 import org.firstinspires.ftc.teamcode.api.Robot;
 import org.firstinspires.ftc.teamcode.api.config.Constants;
 import org.firstinspires.ftc.teamcode.api.config.Naming;
-import org.firstinspires.ftc.teamcode.api.hw.Gyroscope;
 import org.firstinspires.ftc.teamcode.api.hw.SmartServo;
 
 import java.util.concurrent.Executors;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/ConceptVuforiaFieldNavigationWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/ConceptVuforiaFieldNavigationWebcam.java
@@ -34,7 +34,6 @@ import static org.firstinspires.ftc.robotcore.external.navigation.AxesOrder.XYZ;
 import static org.firstinspires.ftc.robotcore.external.navigation.AxesOrder.XZY;
 import static org.firstinspires.ftc.robotcore.external.navigation.AxesReference.EXTRINSIC;
 
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/ConceptVuforiaFieldNavigationWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/ConceptVuforiaFieldNavigationWebcam.java
@@ -131,7 +131,7 @@ public class ConceptVuforiaFieldNavigationWebcam extends LinearOpMode {
         parameters.vuforiaLicenseKey = VUFORIA_KEY;
 
         // We also indicate which camera we wish to use.
-        parameters.cameraName = ClassFactory.getInstance().getCameraManager().nameForSwitchableCamera(webcamFront, webcamLeft, webcamRight);;
+        parameters.cameraName = ClassFactory.getInstance().getCameraManager().nameForSwitchableCamera(webcamFront, webcamLeft, webcamRight);
 
         // Turn off Extended tracking.  Set this true if you want Vuforia to track beyond the target.
         parameters.useExtendedTracking = false;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/LaserTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/LaserTest.java
@@ -1,11 +1,7 @@
 package org.firstinspires.ftc.teamcode.opmode.teleop;
 
-import com.qualcomm.hardware.rev.Rev2mDistanceSensor;
-import com.acmerobotics.dashboard.FtcDashboard;
-import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.util.Range;
 import com.qualcomm.robotcore.hardware.DistanceSensor;
 
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/PositionTelemetry.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/PositionTelemetry.java
@@ -17,9 +17,9 @@ public class PositionTelemetry extends LinearOpMode {
     @Override
     public void runOpMode() throws InterruptedException {
         telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
-        Robot.gyro1 = new Gyroscope(hardwareMap.get(BNO055IMU.class, Naming.GYRO_1), "gyro1");
-        Robot.gyro1.initGyro();
-        Robot.gyro1.calibrateGyro();
+        Robot.setGyro1(new Gyroscope(hardwareMap.get(BNO055IMU.class, Naming.GYRO_1), "gyro1"));
+        Robot.getGyro1().initGyro();
+        Robot.getGyro1().calibrateGyro();
 
         GyroTracker.reset();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/SensorBNO055IMU.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/SensorBNO055IMU.java
@@ -31,7 +31,6 @@ package org.firstinspires.ftc.teamcode.opmode.teleop;
 
 import com.qualcomm.hardware.bosch.BNO055IMU;
 import com.qualcomm.hardware.bosch.JustLoggingAccelerationIntegrator;
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpAlt.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpAlt.java
@@ -1,11 +1,8 @@
 package org.firstinspires.ftc.teamcode.opmode.teleop;
 
-import com.acmerobotics.dashboard.FtcDashboard;
-import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.hardware.Gamepad;
-import com.qualcomm.robotcore.util.Range;
-import org.firstinspires.ftc.teamcode.api.Robot;
+
 import org.firstinspires.ftc.teamcode.api.config.Naming;
 import org.firstinspires.ftc.teamcode.api.opsystems.Controller2Players;
 
@@ -15,99 +12,8 @@ import org.firstinspires.ftc.teamcode.api.opsystems.Controller2Players;
  * -BD103
  */
 @TeleOp(name = "TeleOp Alt", group = Naming.OPMODE_GROUP_COMP)
+@Disabled
+@Deprecated
 public class TeleOpAlt extends Controller2Players {
-    Robot robot = new Robot(this);
 
-    /*
-    * Controller 1
-    *
-    * It can adjust:
-    *
-    * - The core position (forward, backward, strafe, turn)
-    * - The duck wheel (shared)
-    * - The front arm
-    *
-    * Controller 2
-    *
-    * It can adjust:
-    *
-    * - The back arm
-    * - The duck wheel (shared)
-    */
-
-    @Override
-
-    protected void onJoystick(float leftStickX1, float leftStickY1, float rightStickX1, float rightStickY1) {
-        double x1 = Math.pow(leftStickX1, 1.8);
-        double y1 = Math.pow(leftStickY1, 1.8);
-        double rotation = Math.pow(rightStickX1, 1.8);
-
-        double flPower = Range.clip((x1 - y1 + rotation), -1.0, 1.0);
-        double blPower = Range.clip((-x1 - y1 + rotation), -1.0, 1.0);
-        double brPower = Range.clip((x1 - y1 - rotation), -1.0, 1.0);
-        double frPower = Range.clip((-x1 - y1 - rotation), -1.0, 1.0);
-
-        this.robot.powerWheels(flPower, frPower, blPower, brPower);
-    }
-
-    @Override
-    protected void onButton(boolean a1, boolean b1, boolean x1, boolean y1) {
-        if (x1) {
-            robot.openClaw();
-        } else if (b1) {
-            robot.closeClaw();
-        }
-
-        if (y1) {
-            this.robot.armLeft.setPosition(Range.clip(robot.armLeft.getPosition() - 0.001, 0.6, 1));
-            this.robot.armRight.setPosition(Range.clip(robot.armRight.getPosition() - 0.001, 0.6, 1));
-        } else if (a1) {
-            this.robot.armLeft.setPosition(Range.clip(robot.armLeft.getPosition() + 0.001, 0.6, 1));
-            this.robot.armRight.setPosition(Range.clip(robot.armRight.getPosition() + 0.001, 0.6, 1));
-        }
-    }
-
-    @Override
-    protected void onBumper(boolean leftBumper1, boolean rightBumper1, boolean leftBumper2, boolean rightBumper2) {
-        if (leftBumper1 || leftBumper2) {
-            this.robot.powerDuck(0.7);
-        } else if (rightBumper1 || rightBumper2) {
-            this.robot.powerDuck(-0.7);
-        } else {
-            this.robot.powerDuck(0);
-        }
-    }
-
-    @Override
-    public void runOpMode() {
-        Gamepad g1 = gamepad1;
-        Gamepad g2 = gamepad2;
-
-        telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
-
-        telemetry.addData("Status", "Initialized");
-        telemetry.update();
-
-        waitForStart();
-
-        telemetry.addData("Status", "Running");
-
-        while (opModeIsActive()) {
-            this.onJoystick(
-                    g1.left_stick_x,
-                    g1.left_stick_y,
-                    g1.right_stick_x,
-                    g1.right_stick_y
-            );
-            this.onButton(g1.a, g1.b, g1.x, g1.y);
-            this.onBumper(
-                    g1.left_bumper,
-                    g1.right_bumper,
-                    g2.left_bumper,
-                    g2.right_bumper
-            );
-
-            telemetry.update();
-        }
-    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
@@ -68,9 +68,9 @@ public class TeleOpMain extends LinearOpMode {
 
             // Arm movement
             if (gamepad1.dpad_up) {
-                robot.positionArmO(Range.clip(robot.armLefto.getPosition() - 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.armLeft2.getPosition() - 0.01, 0.6, 1));
             } else if (gamepad1.dpad_down) {
-                robot.positionArmO(Range.clip(robot.armLefto.getPosition() + 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.armLeft2.getPosition() + 0.01, 0.6, 1));
             }
 
             if (gamepad2.dpad_up) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
@@ -42,7 +42,7 @@ public class TeleOpMain extends LinearOpMode {
         telemetry.update();
 
         robot.positionClaw(0.1);
-        robot.positionClawO(0.1);
+        robot.positionClaw2(0.1);
 
         while (opModeIsActive()) {
             // Wheel movement
@@ -68,9 +68,9 @@ public class TeleOpMain extends LinearOpMode {
 
             // Arm movement
             if (gamepad1.dpad_up) {
-                robot.positionArmO(Range.clip(robot.getArmLeft2().getPosition() - 0.01, 0.6, 1));
+                robot.positionArm2(Range.clip(robot.getArmLeft2().getPosition() - 0.01, 0.6, 1));
             } else if (gamepad1.dpad_down) {
-                robot.positionArmO(Range.clip(robot.getArmLeft2().getPosition() + 0.01, 0.6, 1));
+                robot.positionArm2(Range.clip(robot.getArmLeft2().getPosition() + 0.01, 0.6, 1));
             }
 
             if (gamepad2.dpad_up) {
@@ -81,9 +81,9 @@ public class TeleOpMain extends LinearOpMode {
 
             // Claw opening / closing
             if (gamepad1.a) {
-                robot.openClawO();
+                robot.openClaw2();
             } else if (gamepad1.b) {
-                robot.closeClawO();
+                robot.closeClaw2();
             }
 
             if (gamepad2.a) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
@@ -20,8 +20,6 @@ import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
-import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.util.Range;
 
 import org.firstinspires.ftc.teamcode.api.Robot;
@@ -35,9 +33,6 @@ public class TeleOpMain extends LinearOpMode {
 
         telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
 
-        robot.fr.setDirection(DcMotorSimple.Direction.REVERSE);
-
-
         telemetry.addData("Status", "Initialized");
         telemetry.update();
 
@@ -46,65 +41,56 @@ public class TeleOpMain extends LinearOpMode {
         telemetry.addData("Status", "Running");
         telemetry.update();
 
-        robot.clawLefto.setPosition(0.1);
-        robot.clawRighto.setPosition(0.1);
+        robot.positionClaw(0.1);
+        robot.positionClawO(0.1);
+
         while (opModeIsActive()) {
+            // Wheel movement
             double x1 = gamepad1.left_stick_x;
             double y1 = gamepad1.left_stick_y;
             double rotation = gamepad1.right_stick_x;
 
-            double flPower = Range.clip(( x1 - y1 + rotation), -1.0, 1.0);
+            double flPower = Range.clip((x1 - y1 + rotation), -1.0, 1.0);
             double blPower = Range.clip((-x1 - y1 + rotation), -1.0, 1.0);
-            double brPower = Range.clip(( x1 - y1 - rotation), -1.0, 1.0);
+            double brPower = Range.clip((x1 - y1 - rotation), -1.0, 1.0);
             double frPower = Range.clip((-x1 - y1 - rotation), -1.0, 1.0);
 
             robot.powerWheels(flPower, frPower, blPower, brPower);
 
-            if (gamepad2.left_bumper) {
+            // Duck wheel logic
+            if ((gamepad1.left_bumper || gamepad2.left_bumper) && !(gamepad1.right_bumper || gamepad2.right_bumper)) {
                 robot.powerDuck(0.7);
-            } else if (gamepad2.right_bumper) {
+            } else if ((gamepad1.right_bumper || gamepad2.right_bumper) && !(gamepad1.left_bumper || gamepad2.left_bumper)) {
                 robot.powerDuck(-0.7);
             } else {
                 robot.powerDuck(0);
             }
 
-            if (gamepad2.dpad_up) {
-                robot.armLeft.setPosition(Range.clip(robot.armLeft.getPosition() - 0.01, 0.5, 1));
-                robot.armRight.setPosition(Range.clip(robot.armRight.getPosition() - 0.01, 0.5, 1));
-            } else if (gamepad2.dpad_down) {
-                robot.armLeft.setPosition(Range.clip(robot.armLeft.getPosition() + 0.01, 0.5, 1));
-                robot.armRight.setPosition(Range.clip(robot.armRight.getPosition() + 0.01, 0.5, 1));
-            }
-
-            if (gamepad2.a) {
-                // Open
-                robot.openClaw();
-            } else if (gamepad2.b) {
-                // Close
-                robot.closeClaw();
-            }
-
+            // Arm movement
             if (gamepad1.dpad_up) {
-                robot.armLefto.setPosition(Range.clip(robot.armLefto.getPosition() - 0.01, 0.6, 1));
-                robot.armRighto.setPosition(Range.clip(robot.armRighto.getPosition() - 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.armLefto.getPosition() - 0.01, 0.6, 1));
             } else if (gamepad1.dpad_down) {
-                robot.armLefto.setPosition(Range.clip(robot.armLefto.getPosition() + 0.01, 0.6, 1));
-                robot.armRighto.setPosition(Range.clip(robot.armRighto.getPosition() + 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.armLefto.getPosition() + 0.01, 0.6, 1));
             }
 
+            if (gamepad2.dpad_up) {
+                robot.positionArm(Range.clip(robot.armLeft.getPosition() - 0.01, 0.5, 1));
+            } else if (gamepad2.dpad_down) {
+                robot.positionArm(Range.clip(robot.armLeft.getPosition() + 0.01, 0.5, 1));
+            }
 
+            // Claw opening / closing
             if (gamepad1.a) {
                 robot.openClawO();
-            } else if (gamepad1.b)    {
+            } else if (gamepad1.b) {
                 robot.closeClawO();
             }
 
-            telemetry.addData("Arm Left", robot.armLeft.getPosition());
-            telemetry.addData("Arm Right", robot.armRight.getPosition());
-            telemetry.addData("Claw Left", robot.clawLeft.getPosition());
-            telemetry.addData("Claw Right", robot.clawRight.getPosition());
-
-            telemetry.update();
+            if (gamepad2.a) {
+                robot.openClaw();
+            } else if (gamepad2.b) {
+                robot.closeClaw();
+            }
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpMain.java
@@ -68,15 +68,15 @@ public class TeleOpMain extends LinearOpMode {
 
             // Arm movement
             if (gamepad1.dpad_up) {
-                robot.positionArmO(Range.clip(robot.armLeft2.getPosition() - 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.getArmLeft2().getPosition() - 0.01, 0.6, 1));
             } else if (gamepad1.dpad_down) {
-                robot.positionArmO(Range.clip(robot.armLeft2.getPosition() + 0.01, 0.6, 1));
+                robot.positionArmO(Range.clip(robot.getArmLeft2().getPosition() + 0.01, 0.6, 1));
             }
 
             if (gamepad2.dpad_up) {
-                robot.positionArm(Range.clip(robot.armLeft.getPosition() - 0.01, 0.5, 1));
+                robot.positionArm(Range.clip(robot.getArmLeft().getPosition() - 0.01, 0.5, 1));
             } else if (gamepad2.dpad_down) {
-                robot.positionArm(Range.clip(robot.armLeft.getPosition() + 0.01, 0.5, 1));
+                robot.positionArm(Range.clip(robot.getArmLeft().getPosition() + 0.01, 0.5, 1));
             }
 
             // Claw opening / closing


### PR DESCRIPTION
This PR does a lot of maintenance to the codebase. There are some breaking changes, but I have alerted @BenRoss00000 beforehand.

- Use the Reformat Code, Optimize Imports, and Auto-Indent Lines features to make everything look good
- Simplify TeleOpMain, plus let both controllers move the duck motor
- Improve the Robot class
  - Remove the step wheel code
  - Use getters and setters for hardware variables
  - Implement missing Arm 2 code
  - Rename all variables and methods for arm 2 to use the "2" suffix instead of "O"
- Deprecate TeleOpAlt, as I will instead focus on improving TeleOpMain
- Make all of Robot's components use getters and setters
- Deprecate TimedSmartDuck
- Optimize SensorSmartDuck to use `sleep()` instead of while loops